### PR TITLE
Start command

### DIFF
--- a/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
@@ -47,7 +47,7 @@ public class Uhc extends JavaPlugin {
         .newCommandRegister(this)
         .register(
             StartCommand.getStartCommand(
-                GameState.newGameState()
+                GameState.newGameState(getServer())
             )
         );
 

--- a/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
@@ -1,5 +1,7 @@
 package com.crimsonwarpedcraft.uhc;
 
+import com.crimsonwarpedcraft.uhc.command.CommandRegister;
+import com.crimsonwarpedcraft.uhc.command.StartCommand;
 import com.crimsonwarpedcraft.uhc.listener.EndDisabler;
 import com.crimsonwarpedcraft.uhc.listener.ListenerRegister;
 import com.crimsonwarpedcraft.uhc.listener.RegenPreventer;
@@ -41,6 +43,14 @@ public class Uhc extends JavaPlugin {
           );
     }
 
+    CommandRegister
+        .newCommandRegister(this)
+        .register(
+            StartCommand.getStartCommand(
+                GameState.newGameState()
+            )
+        );
+
     // Used for registering event listeners with
     ListenerRegister
         .getListenerRegister(this)
@@ -52,6 +62,7 @@ public class Uhc extends JavaPlugin {
         .registerListener(EndDisabler.getEndDisabler())
         .registerListener(UhcUserStoreGarbageCollector.getUhcUserStoreGarbageCollector());
 
+    // TODO Move this border shrinking code to StartCommand
     WorldConfig
         .getWorldConfig(getServer().getWorlds().get(0))
         .setBorderSize(1000)

--- a/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
@@ -61,8 +61,5 @@ public class Uhc extends JavaPlugin {
         .registerListener(ResurrectPreventer.getResurrectPreventer())
         .registerListener(EndDisabler.getEndDisabler())
         .registerListener(UhcUserStoreGarbageCollector.getUhcUserStoreGarbageCollector());
-
-    // TODO Move this border shrinking code to StartCommand
-
   }
 }

--- a/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
@@ -63,9 +63,6 @@ public class Uhc extends JavaPlugin {
         .registerListener(UhcUserStoreGarbageCollector.getUhcUserStoreGarbageCollector());
 
     // TODO Move this border shrinking code to StartCommand
-    WorldConfig
-        .getWorldConfig(getServer().getWorlds().get(0))
-        .setBorderSize(1000)
-        .setBorderSize(500, 300);
+
   }
 }

--- a/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/Uhc.java
@@ -47,7 +47,8 @@ public class Uhc extends JavaPlugin {
         .newCommandRegister(this)
         .register(
             StartCommand.getStartCommand(
-                GameState.newGameState(getServer())
+                GameState.newGameState(getServer()),
+                gameConfig
             )
         );
 

--- a/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
@@ -49,6 +49,7 @@ public class StartCommand extends BaseCommand {
 
       WorldConfig
           .getWorldConfig(game.getWorld("world"))
+          // TODO set difficulty to hardcore
           // TODO set variables for border size and time to shrink
           // TODO prevent border from shrinking for an X amount of time
           .setBorderSize(1000)
@@ -59,7 +60,7 @@ public class StartCommand extends BaseCommand {
         UhcUserStore
             .getInstance()
             .getUhcUser(player)
-            //TODO Reset Player health to 20
+            //TODO Reset Player stats
             .sendMessage(
                 text("Game Has BEGUN!!", NamedTextColor.GREEN)
             );

--- a/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
@@ -1,0 +1,43 @@
+package com.crimsonwarpedcraft.uhc.command;
+
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Description;
+import co.aikar.commands.annotation.Subcommand;
+import com.crimsonwarpedcraft.uhc.GameState;
+import java.util.Objects;
+import org.bukkit.command.CommandSender;
+
+/**
+ * Command to start the game.
+ *
+ * @author Copyright (c) Levi Muniz. All Rights Reserved.
+ */
+@CommandAlias("uhc")
+public class StartCommand extends BaseCommand {
+  private final GameState game;
+
+  /**
+   * Returns an instance of a StartCommand.
+   *
+   * @param game the state of the game
+   */
+  public static StartCommand getStartCommand(GameState game) {
+    return new StartCommand(Objects.requireNonNull(game));
+  }
+
+  private StartCommand(GameState game) {
+    this.game = game;
+  }
+
+  /** Command to start the game. */
+  @Subcommand("start")
+  @Description("Starts the game")
+  @CommandPermission("uhc.admin")
+  public void onStart(CommandSender sender) {
+    // TODO If game is running, start game, start world border shrinking and send message to all
+    //  players, otherwise, send error message to command sender. Consider setting all players'
+    //  health to 20
+  }
+}

--- a/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
@@ -1,7 +1,6 @@
 package com.crimsonwarpedcraft.uhc.command;
 
 import static net.kyori.adventure.text.Component.text;
-import static org.bukkit.Bukkit.getServer;
 
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
@@ -12,7 +11,6 @@ import com.crimsonwarpedcraft.uhc.GameState;
 import com.crimsonwarpedcraft.uhc.WorldConfig;
 import com.crimsonwarpedcraft.uhc.user.UhcUserStore;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
@@ -50,13 +48,13 @@ public class StartCommand extends BaseCommand {
       game.setRunning(true);
 
       WorldConfig
-          .getWorldConfig(getServer().getWorlds().get(0))
+          .getWorldConfig(game.getWorld("world"))
           // TODO set variables for border size and time to shrink
           // TODO prevent border from shrinking for an X amount of time
           .setBorderSize(1000)
           .setBorderSize(500, 300);
 
-      Collection<? extends Player> onlinePlayers = getServer().getOnlinePlayers();
+      Collection<? extends Player> onlinePlayers = game.getOnlinePlayers();
       for (Player player : onlinePlayers) {
         UhcUserStore
             .getInstance()

--- a/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
@@ -7,6 +7,7 @@ import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Subcommand;
+import com.crimsonwarpedcraft.uhc.GameConfig;
 import com.crimsonwarpedcraft.uhc.GameState;
 import com.crimsonwarpedcraft.uhc.WorldConfig;
 import com.crimsonwarpedcraft.uhc.user.UhcUserStore;
@@ -25,18 +26,20 @@ import org.bukkit.entity.Player;
 @CommandAlias("uhc")
 public class StartCommand extends BaseCommand {
   private final GameState game;
+  private final GameConfig config;
 
   /**
    * Returns an instance of a StartCommand.
    *
    * @param game the state of the game
    */
-  public static StartCommand getStartCommand(GameState game) {
-    return new StartCommand(Objects.requireNonNull(game));
+  public static StartCommand getStartCommand(GameState game, GameConfig config) {
+    return new StartCommand(Objects.requireNonNull(game), Objects.requireNonNull(config));
   }
 
-  private StartCommand(GameState game) {
+  private StartCommand(GameState game, GameConfig config) {
     this.game = game;
+    this.config = config;
   }
 
   /** Command to start the game. */
@@ -51,12 +54,15 @@ public class StartCommand extends BaseCommand {
 
       // Sets Config data
       WorldConfig
-          .getWorldConfig(game.getWorld("world"))
+          .getWorldConfig(game.getWorld(config.getMainWorldName()))
           .setDifficulty(Difficulty.HARD) //Sets difficulty to HARD
-          // TODO set variables for border size and time to shrink
           // TODO prevent border from shrinking for an X amount of time
-          .setBorderSize(1000) //Creates World Border
-          .setBorderSize(500, 300); //Shrinks world border
+          .setBorderSize(config.getBorderStartSize()) //Creates World Border
+          //Shrink world border
+          .setBorderSize(
+              config.getBorderShrinkSize(),
+              config.getBorderShrinkSeconds()
+          );
 
       //Lists all players, resets their stats & sends them a BEGIN message
       Collection<? extends Player> onlinePlayers = game.getOnlinePlayers();

--- a/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
@@ -13,6 +13,7 @@ import com.crimsonwarpedcraft.uhc.user.UhcUserStore;
 import java.util.Collection;
 import java.util.Objects;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Difficulty;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -51,7 +52,7 @@ public class StartCommand extends BaseCommand {
       // Sets Config data
       WorldConfig
           .getWorldConfig(game.getWorld("world"))
-          // TODO set difficulty to hardcore
+          .setDifficulty(Difficulty.HARD) //Sets difficulty to HARD
           // TODO set variables for border size and time to shrink
           // TODO prevent border from shrinking for an X amount of time
           .setBorderSize(1000) //Creates World Border
@@ -63,7 +64,11 @@ public class StartCommand extends BaseCommand {
         UhcUserStore
             .getInstance()
             .getUhcUser(player)
-            //TODO Reset Player stats
+            .resetHealth()
+            .resetHunger()
+            .resetSaturation()
+            .resetExhaustion()
+            .resetExp()
             .sendMessage(
                 text("Game Has BEGUN!!", NamedTextColor.GREEN)
             );

--- a/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
@@ -44,17 +44,20 @@ public class StartCommand extends BaseCommand {
   @CommandPermission("uhc.admin")
   public void onStart(CommandSender sender) {
 
+    // If game is not already running, starts the game
     if (!game.isRunning()) {
       game.setRunning(true);
 
+      // Sets Config data
       WorldConfig
           .getWorldConfig(game.getWorld("world"))
           // TODO set difficulty to hardcore
           // TODO set variables for border size and time to shrink
           // TODO prevent border from shrinking for an X amount of time
-          .setBorderSize(1000)
-          .setBorderSize(500, 300);
+          .setBorderSize(1000) //Creates World Border
+          .setBorderSize(500, 300); //Shrinks world border
 
+      //Lists all players, resets their stats & sends them a BEGIN message
       Collection<? extends Player> onlinePlayers = game.getOnlinePlayers();
       for (Player player : onlinePlayers) {
         UhcUserStore
@@ -68,6 +71,7 @@ public class StartCommand extends BaseCommand {
 
       // TODO save online players into whitelist, save old whitelist and replace it back on game end
 
+    // If game is already running, sends an error message
     } else {
       UhcUserStore
           .getInstance()

--- a/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
+++ b/src/main/java/com/crimsonwarpedcraft/uhc/command/StartCommand.java
@@ -1,13 +1,22 @@
 package com.crimsonwarpedcraft.uhc.command;
 
+import static net.kyori.adventure.text.Component.text;
+import static org.bukkit.Bukkit.getServer;
+
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.Subcommand;
 import com.crimsonwarpedcraft.uhc.GameState;
+import com.crimsonwarpedcraft.uhc.WorldConfig;
+import com.crimsonwarpedcraft.uhc.user.UhcUserStore;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 /**
  * Command to start the game.
@@ -36,8 +45,37 @@ public class StartCommand extends BaseCommand {
   @Description("Starts the game")
   @CommandPermission("uhc.admin")
   public void onStart(CommandSender sender) {
-    // TODO If game is running, start game, start world border shrinking and send message to all
-    //  players, otherwise, send error message to command sender. Consider setting all players'
-    //  health to 20
+
+    if (!game.isRunning()) {
+      game.setRunning(true);
+
+      WorldConfig
+          .getWorldConfig(getServer().getWorlds().get(0))
+          // TODO set variables for border size and time to shrink
+          // TODO prevent border from shrinking for an X amount of time
+          .setBorderSize(1000)
+          .setBorderSize(500, 300);
+
+      Collection<? extends Player> onlinePlayers = getServer().getOnlinePlayers();
+      for (Player player : onlinePlayers) {
+        UhcUserStore
+            .getInstance()
+            .getUhcUser(player)
+            //TODO Reset Player health to 20
+            .sendMessage(
+                text("Game Has BEGUN!!", NamedTextColor.GREEN)
+            );
+      }
+
+      // TODO save online players into whitelist, save old whitelist and replace it back on game end
+
+    } else {
+      UhcUserStore
+          .getInstance()
+          .getUhcUser(sender)
+          .sendMessage(
+              text("Error: Game Already Running", NamedTextColor.RED)
+          );
+    }
   }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,10 @@ api-version: "1.16"
 author: Levi Muniz
 description: A simple UHC plugin
 
+commands:
+  uhc:
+    description: Base command for UHC
+
 permissions:
   uhc.admin:
     description: Gives players access to administrative commands

--- a/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
+++ b/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
@@ -1,5 +1,6 @@
 package com.crimsonwarpedcraft.uhc.command;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,6 +10,9 @@ import com.crimsonwarpedcraft.uhc.mock.MockPlayer;
 import com.crimsonwarpedcraft.uhc.mock.MockServer;
 import com.crimsonwarpedcraft.uhc.mock.MockWorld;
 import net.kyori.adventure.text.Component;
+import org.bukkit.Difficulty;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -20,27 +24,67 @@ class StartCommandTest {
 
   @Test
   void onStart() {
-    MockPlayer player = new MockPlayer();
+    MockPlayer player1 = new MockPlayer();
+    player1.setHealth(10);
+    AttributeInstance attribute = player1.getAttribute(Attribute.GENERIC_MAX_HEALTH);
+    assertNotNull(attribute);
+    attribute.setBaseValue(2);
+    player1.setExp(10);
+    player1.setExhaustion(5);
+    player1.setSaturation(0);
+    player1.setFoodLevel(5);
+    MockPlayer player2 = new MockPlayer();
+
     MockServer server = new MockServer();
-    server.addPlayer(player);
-    server.loadWorld(new MockWorld());
+    server.addPlayer(player1);
+    server.addPlayer(player2);
+
+    MockWorld world = new MockWorld();
+    world.getWorldBorder().setSize(5);
+    world.setDifficulty(Difficulty.PEACEFUL);
+    server.loadWorld(world);
+
     GameState game = GameState.newGameState(server);
     StartCommand start = StartCommand.getStartCommand(game);
 
     // Run the start command
-    start.onStart(player);
+    start.onStart(player2);
 
     // Check that the game is running
     assertTrue(game.isRunning());
 
     // Make sure the player was sent a message
-    Component message = player.getLastMessage();
+    Component message = player2.getLastMessage();
     assertNotNull(message);
 
+    // Make sure that all players were sent a message
+    assertNotNull(player1.getLastMessage());
+
+    // Make sure players' health were reset
+    assertNotEquals(10, player1.getHealth());
+
+    // Make sure players' max health were reset
+    assertNotEquals(2, attribute.getBaseValue());
+
+    // Make sure players' food level were reset
+    assertNotEquals(5, player1.getFoodLevel());
+
+    // Make sure players' experience were reset
+    assertNotEquals(10, player1.getExp());
+
+    // Make sure players' saturation were reset
+    assertNotEquals(10, player1.getSaturation());
+
+    // Make sure that the world border was set
+    assertNotEquals(5, world.getWorldBorder().getSize());
+
+    // Make sure that the difficulty was set to hardcore
+    assertEquals(Difficulty.HARD, world.getDifficulty());
+
     // Run the start command again
-    start.onStart(player);
+    start.onStart(player2);
 
     // Check that the player was sent a different message
-    assertNotEquals(message, player.getLastMessage());
+    assertNotEquals(message, player2.getLastMessage());
   }
 }

--- a/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
+++ b/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.crimsonwarpedcraft.uhc.GameState;
 import com.crimsonwarpedcraft.uhc.mock.MockPlayer;
 import com.crimsonwarpedcraft.uhc.mock.MockServer;
+import com.crimsonwarpedcraft.uhc.mock.MockWorld;
 import net.kyori.adventure.text.Component;
 import org.junit.jupiter.api.Test;
 
@@ -19,9 +20,12 @@ class StartCommandTest {
 
   @Test
   void onStart() {
-    GameState game = GameState.newGameState(new MockServer());
-    StartCommand start = StartCommand.getStartCommand(game);
     MockPlayer player = new MockPlayer();
+    MockServer server = new MockServer();
+    server.addPlayer(player);
+    server.loadWorld(new MockWorld());
+    GameState game = GameState.newGameState(server);
+    StartCommand start = StartCommand.getStartCommand(game);
 
     // Run the start command
     start.onStart(player);

--- a/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
+++ b/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
@@ -1,18 +1,23 @@
 package com.crimsonwarpedcraft.uhc.command;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.crimsonwarpedcraft.uhc.GameConfig;
 import com.crimsonwarpedcraft.uhc.GameState;
 import com.crimsonwarpedcraft.uhc.mock.MockPlayer;
 import com.crimsonwarpedcraft.uhc.mock.MockServer;
 import com.crimsonwarpedcraft.uhc.mock.MockWorld;
+import java.nio.file.Paths;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Difficulty;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,12 +45,23 @@ class StartCommandTest {
     server.addPlayer(player2);
 
     MockWorld world = new MockWorld();
+    world.setName("world1");
     world.getWorldBorder().setSize(5);
     world.setDifficulty(Difficulty.PEACEFUL);
     server.loadWorld(world);
 
+    FileConfiguration config = new YamlConfiguration();
+    assertDoesNotThrow(
+        () -> config.load(
+            Paths.get("src", "test", "resources", "config.yml").toFile()
+        )
+    );
+
     GameState game = GameState.newGameState(server);
-    StartCommand start = StartCommand.getStartCommand(game);
+    StartCommand start = StartCommand.getStartCommand(
+        game,
+        GameConfig.getNewGameConfig(config)
+    );
 
     // Run the start command
     start.onStart(player2);
@@ -77,6 +93,8 @@ class StartCommandTest {
 
     // Make sure that the world border was set
     assertNotEquals(5, world.getWorldBorder().getSize());
+
+    // TODO: Maybe check if the border shrinks?
 
     // Make sure that the difficulty was set to hardcore
     assertEquals(Difficulty.HARD, world.getDifficulty());

--- a/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
+++ b/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
@@ -1,0 +1,41 @@
+package com.crimsonwarpedcraft.uhc.command;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.crimsonwarpedcraft.uhc.GameState;
+import com.crimsonwarpedcraft.uhc.mock.MockPlayer;
+import net.kyori.adventure.text.Component;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for StartCommand.
+ *
+ * @author Copyright (c) Levi Muniz. All Rights Reserved.
+ */
+class StartCommandTest {
+
+  @Test
+  void onStart() {
+    GameState game = GameState.newGameState();
+    StartCommand start = StartCommand.getStartCommand(game);
+    MockPlayer player = new MockPlayer();
+
+    // Run the start command
+    start.onStart(player);
+
+    // Check that the game is running
+    assertTrue(game.isRunning());
+
+    // Make sure the player was sent a message
+    Component message = player.getLastMessage();
+    assertNotNull(message);
+
+    // Run the start command again
+    start.onStart(player);
+
+    // Check that the player was sent a different message
+    assertNotEquals(message, player.getLastMessage());
+  }
+}

--- a/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
+++ b/src/test/java/com/crimsonwarpedcraft/uhc/command/StartCommandTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.crimsonwarpedcraft.uhc.GameState;
 import com.crimsonwarpedcraft.uhc.mock.MockPlayer;
+import com.crimsonwarpedcraft.uhc.mock.MockServer;
 import net.kyori.adventure.text.Component;
 import org.junit.jupiter.api.Test;
 
@@ -18,7 +19,7 @@ class StartCommandTest {
 
   @Test
   void onStart() {
-    GameState game = GameState.newGameState();
+    GameState game = GameState.newGameState(new MockServer());
     StartCommand start = StartCommand.getStartCommand(game);
     MockPlayer player = new MockPlayer();
 

--- a/src/test/java/com/crimsonwarpedcraft/uhc/mock/MockWorld.java
+++ b/src/test/java/com/crimsonwarpedcraft/uhc/mock/MockWorld.java
@@ -66,6 +66,7 @@ import org.jetbrains.annotations.Nullable;
 @SuppressFBWarnings("NP_NONNULL_RETURN_VIOLATION")
 public class MockWorld implements World {
   private final WorldBorder border = new MockWorldBorder();
+  private String name = "world";
   private Difficulty difficulty = Difficulty.NORMAL;
 
   @Override
@@ -499,7 +500,11 @@ public class MockWorld implements World {
 
   @Override
   public @NotNull String getName() {
-    return "world";
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   @Override


### PR DESCRIPTION
Adds a start command to the plugin. Running the start command creates a shrinking world border and resets players' stats. This PR also includes the CommandRegister class which is used to register commands.

Resolves #13